### PR TITLE
Fix nil error

### DIFF
--- a/lua/autorun/client/cl_gazing.lua
+++ b/lua/autorun/client/cl_gazing.lua
@@ -195,8 +195,10 @@ local function gazeTick()
         hook.Remove( "RenderScreenspaceEffects", "TheOrb_Gazing" )
         timer.Remove( "TheOrb_DelayScreaming" )
 
-        chantSound:Stop()
-        chantSound = nil
+        if chantSound then
+            chantSound:Stop()
+            chantSound = nil
+        end
 
         screamSound:Stop()
     end


### PR DESCRIPTION
CL error:
```
addons/the_orb/lua/autorun/client/cl_gazing.lua:198: attempt to index upvalue 'chantSound' (a nil value)
  1. fn - addons/the_orb/lua/autorun/client/cl_gazing.lua:198
   2. unknown - addons/ulib/lua/ulib/shared/hook.lua:109
```