### PR TITLE
Fix dynamiclight error

### DIFF
--- a/lua/entities/the_orb/cl_init.lua
+++ b/lua/entities/the_orb/cl_init.lua
@@ -43,7 +43,7 @@ function ENT:PlaySparkSound( pos )
 end
 
 function ENT:MakeFlash( pos )
-    local light = DynamicLight()
+    local light = DynamicLight( self:EntIndex() )
     if not light then return end
 
     light.Pos = pos + self.LightOffset


### PR DESCRIPTION
Should fix
```
[the_orb] addons/the_orb/lua/entities/the_orb/cl_init.lua:46: bad argument #1 to 'DynamicLight' (number expected, got no value)
  1. DynamicLight - [C]:-1
   2. MakeFlash - addons/the_orb/lua/entities/the_orb/cl_init.lua:46
    3. Zap - addons/the_orb/lua/entities/the_orb/cl_init.lua:85
     4. unknown - addons/the_orb/lua/entities/the_orb/cl_init.lua:94
```